### PR TITLE
Cache AUTOLOAD-generated methods for future use

### DIFF
--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -205,10 +205,22 @@ sub DESTROY { }
 our $AUTOLOAD;
 
 sub AUTOLOAD {
-  my $self = shift;
-
   my $command = $AUTOLOAD;
   $command =~ s/.*://;
+
+  my $method = sub { shift->__std_cmd($command, @_) };
+
+  # Save this method for future calls
+  no strict 'refs';
+  *$AUTOLOAD = $method;
+
+  goto $method;
+}
+
+sub __std_cmd {
+  my $self    = shift;
+  my $command = shift;
+
   $self->__is_valid_command($command);
 
   ## Fast path, no reconnect


### PR DESCRIPTION
This addresses issue #2.

Results of timing comparisons (using a slightly modified implementation that's more amenable to simultaneous benchmarking in a single Perl interpreter) can be found in arc@ba54b38; see the notes at the bottom of the timing.pl file in that commit.  Short version: we get about 12% performance improvement from caching `AUTOLOAD` methods.
