### PR TITLE
fix for perl-redis issue #20

### DIFF
--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -577,7 +577,7 @@ sub __try_read_sock {
   my $data = '';
 
   __fh_nonblocking($sock, 1);
-  my $result = read($sock, $data, 1);
+  my $result = sysread($sock, $data, 1);
   my $err = 0 + $!;
   __fh_nonblocking($sock, 0);
 


### PR DESCRIPTION
Sysread fixes the Windows issue reported here:
https://github.com/melo/perl-redis/issues/20
