### PR TITLE
Implement support for multi-word Redis commands such as "script load"

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Redis
 
 {{$NEXT}}
+    * Support for multi-word commands such as "SCRIPT LOAD".
 
 1.953     2012-09-05T00:49:11Z
     * Tweak travis.ci setup

--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -446,9 +446,10 @@ sub __send_command {
   warn "[SEND] $cmd ", Dumper([@_]) if $deb;
 
   ## Encode command using multi-bulk format
-  my $n_elems = scalar(@_) + 1;
+  my @cmd = split /_/, $cmd;
+  my $n_elems = scalar(@_) + scalar(@cmd);
   my $buf     = "\*$n_elems\r\n";
-  for my $elem ($cmd, @_) {
+  for my $elem (@cmd, @_) {
     my $bin = $enc ? encode($enc, $elem) : $elem;
     $buf .= defined($bin) ? '$' . length($bin) . "\r\n$bin\r\n" : "\$-1\r\n";
   }

--- a/t/30-scripts.t
+++ b/t/30-scripts.t
@@ -1,0 +1,38 @@
+#!perl
+
+use warnings;
+use strict;
+use Test::More;
+use Test::Exception;
+use Redis;
+use lib 't/tlib';
+use Test::SpawnRedisServer;
+use Digest::SHA1 qw(sha1_hex);
+
+my ($c, $srv) = redis();
+END { $c->() if $c }
+
+
+ok(my $o = Redis->new(server => $srv), 'connected to our test redis-server');
+ok($o->ping, 'ping');
+
+## Commands related to Lua scripting
+
+# Specifically, these commands test multi-word commands
+
+ok($o->set(foo => 'bar'), 'set foo => bar');
+
+$o->script_flush;
+
+my $script = "return 1";
+my $script_sha = sha1_hex($script);
+die ($script_sha);
+my @ret = $o->script_exists($script_sha);
+ok(@ret && $ret[0] == 0, "script exists returns false");
+ok($o->script_load($script), "script load returns true");
+ok($o->script_exists($script_sha), "script exists returns true after loading");
+ok($o->evalsha($script_sha, 0), "eval returns true");
+ok($o->eval($script, 0), "eval returns true");
+
+## All done
+done_testing();


### PR DESCRIPTION
Things like ->script_exists and ->script_load use sub-commands that need
to be encoded as:

  *3
  $6
  SCRIPT
  $6
  EXISTS
  $40
  e0e1f9fabfc9d4800c877a703b823ac0578ff8db

This change just basically splits all commands (coming from method
names) on "_" and issues them in the above fashion.
