### PR TITLE
Fix tests for 2.6.13

### DIFF
--- a/t/07-reconnect.t
+++ b/t/07-reconnect.t
@@ -67,13 +67,13 @@ subtest 'KEYS commands with extra logic triggers reconnect' => sub {
 };
 
 
-subtest "Bad commnands don't trigger reconnect" => sub {
+subtest "Bad commands don't trigger reconnect" => sub {
   ok(my $r = Redis->new(reconnect => 2, server => $srv), 'connected to our test redis-server');
 
   my $prev_sock = "$r->{sock}";
   like(
     exception { $r->set(bad => reconnect => 1) },
-    qr{ERR wrong number of arguments for 'set' command},
+    qr{ERR wrong number of arguments for 'set' command|\[set\] ERR syntax error},
     'Bad commands still die',
   );
   is("$r->{sock}", $prev_sock, "... and don't trigger a reconnect");


### PR DESCRIPTION
Tests were failing with this:

``` text
    ok 1 - connected to our test redis-server
    not ok 2 - Bad commands still die

    #   Failed test 'Bad commands still die'
    #   at t/07-reconnect.t line 76.
    #                   '[set] ERR syntax error,  at /home/al/.cpanm/work/1367968439.18598/Redis-1.961/lib/Redis.pm line 163, <GEN17> line 1.
    #   Redis::__ANON__(undef, 'ERR syntax error') called at /home/al/.cpanm/work/1367968439.18598/Redis-1.961/lib/Redis.pm line 195
    #   Redis::wait_one_response('Redis=HASH(0x7fc2e0)') called at /home/al/.cpanm/work/1367968439.18598/Redis-1.961/lib/Redis.pm line 183
    #   Redis::wait_all_responses('Redis=HASH(0x7fc2e0)') called at /home/al/.cpanm/work/1367968439.18598/Redis-1.961/lib/Redis.pm line 172
    #   Redis::__run_cmd('Redis=HASH(0x7fc2e0)', 'set', undef, undef, undef, 'bad', 'reconnect', 1) called at /home/al/.cpanm/work/1367968439.18598/Redis-1.961/lib/Redis.pm line 130
    #   Redis::__ANON__() called at /home/al/perl5/perlbrew/perls/perl-5.16.3/lib/site_perl/5.16.3/Try/Tiny.pm line 76
    #   eval {...} called at /home/al/perl5/perlbrew/perls/perl-5.16.3/lib/site_perl/5.16.3/Try/Tiny.pm line 67
    #   Try::Tiny::try('CODE(0x12cb6d8)', 'Try::Tiny::Catch=REF(0x77cd70)') called at /home/al/.cpanm/work/1367968439.18598/Redis-1.961/lib/Redis.pm line 149
    #   Redis::__with_reconnect('Redis=HASH(0x7fc2e0)', 'CODE(0x12cb6d8)') called at /home/al/.cpanm/work/1367968439.18598/Redis-1.961/lib/Redis.pm line 132
    #   Redis::__std_cmd('Redis=HASH(0x7fc2e0)', 'set', 'bad', 'reconnect', 1) called at /home/al/.cpanm/work/1367968439.18598/Redis-1.961/lib/Redis.pm line 101
    #   Redis::__ANON__('Redis=HASH(0x7fc2e0)', 'bad', 'reconnect', 1) called at t/07-reconnect.t line 75
    #   main::__ANON__() called at /home/al/perl5/perlbrew/perls/perl-5.16.3/lib/site_perl/5.16.3/Test/Fatal.pm line 23
    #   Test::Fatal::__ANON__() called at /home/al/perl5/perlbrew/perls/perl-5.16.3/lib/site_perl/5.16.3/Try/Tiny.pm line 71
    #   eval {...} called at /home/al/perl5/perlbrew/perls/perl-5.16.3/lib/site_perl/5.16.3/Try/Tiny.pm line 67
    #   Try::Tiny::try('CODE(0xfb4cc8)', 'Try::Tiny::Catch=REF(0x11cb8f0)') called at /home/al/perl5/perlbrew/perls/perl-5.16.3/lib/site_perl/5.16.3/Test/Fatal.pm line 30
    #   Test::Fatal::exception('CODE(0xfb44a0)') called at t/07-reconnect.t line 76
    #   main::__ANON__() called at /home/al/perl5/perlbrew/perls/perl-5.16.3/lib/5.16.3/Test/Builder.pm line 234
    #   Test::Builder::__ANON__() called at /home/al/perl5/perlbrew/perls/perl-5.16.3/lib/5.16.3/Test/Builder.pm line 239
    #   eval {...} called at /home/al/perl5/perlbrew/perls/perl-5.16.3/lib/5.16.3/Test/Builder.pm line 239
    #   Test::Builder::subtest('Test::Builder=HASH(0x77cba8)', 'Bad commnands don\'t trigger reconnect', 'CODE(0xb31a08)') called at /home/al/perl5/perlbrew/perls/perl-5.16.3/lib/5.16.3/Test/More.pm line 747
    #   Test::More::subtest('Bad commnands don\'t trigger reconnect', 'CODE(0xb31a08)') called at t/07-reconnect.t line 80
    # '
    #     doesn't match '(?^:ERR wrong number of arguments for 'set' command)'
    ok 3 - ... and don't trigger a reconnect
    1..3
    # Looks like you failed 1 test of 3.
not ok 6 - Bad commnands don't trigger reconnect
```
