### PR TITLE
Add documentation for the slowlog command

### DIFF
--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -1512,6 +1512,13 @@ modes.
 
 The C<shutdown> method does not support pipelined operation.
 
+=head3 slowlog
+
+  my $nr_items = $r->slowlog("len");
+  my @last_ten_items = $r->slowlog("get", 10);
+
+The C<slowlog> command gives access to the server's slow log.
+
 
 =head2 Multiple databases handling commands
 


### PR DESCRIPTION
This command is working, since Redis 2.2.12 I believe,
but is not documented in the POD.
