### PR TITLE
Support for IPv6 in redis 2.8, updated tests to 2.8, make it work also on an IPv6-only host

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -98,7 +98,7 @@ ok(my $nr_keys = $o->dbsize, 'dbsize');
 
 like(
   exception { $o->lpush('foo', 'bar') },
-  qr/\[lpush\] ERR Operation against a key holding the wrong kind of value,/,
+  qr/\[lpush\] (?:ERR|WRONGTYPE) Operation against a key holding the wrong kind of value,/,
   'Error responses throw exception'
 );
 
@@ -351,7 +351,7 @@ ok(!$o->ping(),     'ping() will be false after shutdown()');
 sleep(1);
 like(
   exception { Redis->new(server => $srv) },
-  qr/Could not connect to Redis server at $srv/,
+  qr/Could not connect to Redis server at \Q$srv\E/,
   'Failed connection throws exception'
 );
 

--- a/t/04-pipeline.t
+++ b/t/04-pipeline.t
@@ -69,7 +69,7 @@ pipeline_ok 'transaction',
   [rpush => ['clunk' => 'oops'], 'QUEUED'],
   [get => ['clunk'], 'QUEUED'],
   [ exec => [],
-    [['OK', undef], [undef, 'ERR Operation against a key holding the wrong kind of value'], ['eth', undef],]
+    [['OK', undef], [undef, re(qr{^(?:ERR|WRONGTYPE) Operation against a key holding the wrong kind of value$})], ['eth', undef],]
   ],
   );
 
@@ -80,7 +80,7 @@ subtest 'transaction with error and no pipeline' => sub {
   is($r->get('clunk'), 'QUEUED', 'transactional GET');
   like(
     exception { $r->exec },
-    qr{\[exec\] ERR Operation against a key holding the wrong kind of value,},
+    qr{\[exec\] (?:ERR|WRONGTYPE) Operation against a key holding the wrong kind of value,},
     'synchronous EXEC dies for intervening error'
   );
 };

--- a/t/07-reconnect.t
+++ b/t/07-reconnect.t
@@ -73,7 +73,7 @@ subtest "Bad commnands don't trigger reconnect" => sub {
   my $prev_sock = "$r->{sock}";
   like(
     exception { $r->set(bad => reconnect => 1) },
-    qr{ERR wrong number of arguments for 'set' command},
+    qr{ERR wrong number of arguments for 'set' command|\[set\] ERR syntax error},
     'Bad commands still die',
   );
   is("$r->{sock}", $prev_sock, "... and don't trigger a reconnect");


### PR DESCRIPTION
Now that redis server 2.8 finally supports IPv6, some updates are needed on the client side too. The old IO::Socket::INET perl module does not support IPv6, but there are two Perl CPAN socket modules that do support both protocol families: an oldish IO::Socket::INET6, and a modern and actively maintained IO::Socket::IP.

The proposed change to Redis.pm choses one of the available IO::Socket::\* modules and updates $self->{server} to an arrayref of IP or Unix socket specifications to be tried in order, the first one that succeeds will be used.

The list is needed to choose a suitable default IP server specification, as it is not known in advance on which protocol family the server listens on a loopback interface (e.g. on an IPv6-only host the loopback interface does not have address 127.0.0.1, only the ::1 ). Once we settle for a list for a choice of servers, it can be handy to let a caller specify alternative server choices too.

The change also updates several tests, as the 2.8 redis server has changed some error types or error strings.

The SpawnRedisServer.pm is modified to let it chose between 127.0.0.1 and ::1 for the test server based on availability of protocol families support. This makes it possible for tests to auto-detect an IPv6-only or IPv4-only or dual-stack host. It may appear that using 'localhost' instead of testing IP addresses would be a cleaner solution, but that only works in a 'bind' config of a 2.8 server, and the older IO::Socket::INET6 module does not try multiple IP addresses resolved from 'localhost', so hard-coded IP addresses seem to be the more reliable choice.
