### PR TITLE
Fixed POD for hset

### DIFF
--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -1291,8 +1291,8 @@ of this module t/01-basic.t
 =head3 hset
 
 Sets the value to a key in a hash.
-  $r->hset('hashname', $key => $value); ## returns true on success
 
+  $r->hset('hashname', $key => $value); ## returns true on success
 
 =head3 hget
   


### PR DESCRIPTION
The code example for hset in the POD is not rendered correctly, not as 'code'. See screenshot below. This commit fixes it.

![POD screenshot](https://f.cloud.github.com/assets/659504/1663563/2ca910e4-5c17-11e3-85f2-a8f034f17bd3.png)
