### PR TITLE
Redis->new(server=>'') does not connect to localhost:6379 #77

### DIFF
--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -33,7 +33,7 @@ sub new {
   $self->{debug} = $args{debug} || $ENV{REDIS_DEBUG};
 
   ## Deal with REDIS_SERVER ENV
-  if ($ENV{REDIS_SERVER} && !$args{sock} && !$args{server}) {
+  if ($ENV{REDIS_SERVER} && !$args{sock} && ! exists $args{server}) {
     if ($ENV{REDIS_SERVER} =~ m!^/!) {
       $args{sock} = $ENV{REDIS_SERVER};
     }
@@ -60,7 +60,7 @@ sub new {
   $self->{reconnect}     = $args{reconnect} || 0;
   $self->{every}         = $args{every} || 1000;
 
-  if ($args{sock}) {
+  if (exists $args{sock}) {
     $self->{server} = $args{sock};
     $self->{builder} = sub {
         my ($self) = @_;


### PR DESCRIPTION
Old logic causes subtle issues in some cases.
Redis->new() remains behaves as used to be, connection to localhost:6379
