### PR TITLE
Fixing inconsistency with binary strings (called "the unicode bug").

### DIFF
--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -16,7 +16,6 @@ use Fcntl qw( O_NONBLOCK F_SETFL );
 use Errno ();
 use Data::Dumper;
 use Carp;
-use Encode;
 use Try::Tiny;
 use Scalar::Util ();
 
@@ -686,8 +685,6 @@ sub __send_command {
   my $n_elems = scalar(@_) + scalar(@cmd);
   my $buf     = "\*$n_elems\r\n";
   for my $bin (@cmd, @_) {
-    # force to consider inputs as bytes strings.
-    Encode::_utf8_off($bin);
     $buf .= defined($bin) ? '$' . length($bin) . "\r\n$bin\r\n" : "\$-1\r\n";
   }
 
@@ -1043,11 +1040,10 @@ useful for Redis transactions; see L</exec>.
 =head1 ENCODING
 
 There is no encoding feature anymore, it has been deprecated and finally
-removed. This module consider that any data sent to the Redis server is a raw
-octets string, even if it has utf8 flag set. And it doesn't do anything when
-getting data from the Redis server.
+removed. This module consider that any data sent to the Redis server is a binary data.
+And it doesn't do anything when getting data from the Redis server.
 
-So, do you pre-encoding or post-decoding operation yourself if needed !
+So, if you are working with character strings, you should pre-encode or post-decode it if needed !
 
 =head1 METHODS
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -45,9 +45,11 @@ ok($o->set(foo => 'baz'), 'set foo => baz');
 cmp_ok($o->get('foo'), 'eq', 'baz', 'get foo = baz');
 
 my $euro = "\x{20ac}";
-ok($o->set(utf8 => $euro), 'set utf8');
-use Encode;
-cmp_ok(Encode::decode_utf8($o->get('utf8')), 'eq', $euro, 'get utf8');
+ok ord($euro) > 255, "assume \$eur is wide character";
+ok ! eval { $o->set(utf8 => $euro); 1 }, "accepts only binary data, thus crashes on strings with characters > 255";
+like "$@", qr/Wide.*syswrite/i, ".. and crashes on syswrite call";
+
+ok ! defined $o->get('utf8'), ".. and does not write actual data";
 
 ok($o->set('test-undef' => 42), 'set test-undef');
 ok($o->exists('test-undef'), 'exists undef');

--- a/t/44-no-unicode-bug.t
+++ b/t/44-no-unicode-bug.t
@@ -1,0 +1,23 @@
+#!perl
+
+use warnings;
+use strict;
+use Test::More;
+use Test::Fatal;
+use Redis;
+use lib 't/tlib';
+use Test::SpawnRedisServer;
+
+my ($c, $srv) = redis();
+END { $c->() if $c }
+
+ok(my $r = Redis->new(server => $srv), 'connected to our test redis-server');
+my $s2 = my $s1 = "test\x{80}";
+utf8::upgrade($s1); # no need to use 'use utf8' to call this
+utf8::downgrade($s2); # no need to use 'use utf8' to call this
+ok ($s1 eq $s2, 'assume test string are considered identical by perl');
+$r->set($s1 => 42);
+is $r->get($s2), 42, "same binary strings should point to same keys";
+
+## All done
+done_testing();


### PR DESCRIPTION
In perl, string which are identical (eq operator) should behave as same strings.
Fixing inconsistency when binary strings with UTF-8 flag set and flag clear
behave different way.

Intention of the module to consider all input and output data as binary data,
proper way to implement this does not involve call to _utf8_off, instead
it just works in pure-perl.

If data with wide characters is sent (i.e. characters with code > 255), it's can't
be downgaded, thus cannot be considered as binary string, thus exception
"Wide characters in syswrite" is thrown.

Fixes #95
