### PR TITLE
Abstracted away some error messages

### DIFF
--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -7,6 +7,9 @@ package Redis;
 use warnings;
 use strict;
 
+sub EX_RECONNECT_DISABLED_TRANSACTION { "reconnect disabled inside transaction or watch" }
+sub EX_RECONNECT_DISABLED_WAITING_REPLY { "reconnect disabled while responses are pending and conservative reconnect mode enabled" }
+
 use IO::Socket::INET;
 use IO::Socket::UNIX;
 use IO::Socket::Timeout;
@@ -247,10 +250,10 @@ sub __with_reconnect {
         or die $_;
 
       $self->{__inside_transaction} || $self->{__inside_watch}
-        and croak("reconnect disabled inside transaction or watch");
+        and croak( EX_RECONNECT_DISABLED_TRANSACTION() );
 
       scalar @{$self->{queue} || []} && $self->{conservative_reconnect}
-        and croak("reconnect disabled while responses are pending and conservative reconnect mode enabled");
+        and croak( EX_RECONNECT_DISABLED_WAITING_REPLY() );
 
       $self->connect;
       $cb->();


### PR DESCRIPTION
Hi.

This is done to help folks catch exceptions from this module and to be more error prone to module updates.

Why have I abstracted only these ones?
I've chosen errors that may arise unexpectedly, at random times and not as a result of programmer errors. Most others should be fixed by changing client code once instead of trapping inside eval, and rest are fatal enough for catch-all logic (no need to catch them individually because we can't fix it - everything just broke too hard). IMHO.
