### PR TITLE
Sentinel role support

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Redis
 
 {{$NEXT}}
+   * add supporte for new()'s "role" parameter: connect to slaves using
+     Sentinel for discovery
 
 1.979     2015-05-14 14:28:35CEST+0200 Europe/Amsterdam
 

--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -1156,16 +1156,18 @@ where the Redis server is listening.
 
 =head3 C<< sentinels >> and C<< service >>
 
-The C<< sentinels >> and the C<< service >> parameters specify a list of sentinels to contact and try to get the
-address of the servers supporting the given service name.
+The C<< sentinels >> and the C<< service >> parameters specify a list of
+sentinels to contact and try to get the address of the servers
+supporting the given service name.
 
 The C<< sentinels >> parameter must be an ArrayRef
 and C<< service >> an Str.
 
-By default this will connect you to the
-master instance of the service, but you can use the C<< role >> set as
-"slave" to randomly connect to one of the slaves. If no slaves are
-found, the connect call will die. Please note that this means that you can also die on reconnects.
+By default this will connect you to the master instance of the service,
+but you can use the C<< role >> set as "slave" to randomly connect to
+one of the slaves. If no slaves are found, the connect call will die.
+
+Please note that this means that you can also die on reconnects.
 
 =head3 C<< REDIS_SERVER ENV >>
 

--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -1079,6 +1079,33 @@ So, if you are working with character strings, you should pre-encode or post-dec
                             sentinels_write_timeout => 1,
                           );
 
+Creates a L<< Redis >> instance and connects to a Redis server.
+
+The constructor will try to find the server to connect to using multiple methods, in the sequence below. The first found is used.
+
+=over
+
+=item *
+
+the C<< sock >> parameter;
+
+=item *
+
+the C<< sentinels >> parameter;
+
+=item *
+
+the C<< server >> parameter;
+
+=item *
+
+the C<< REDIS_SERVER >> environment variable.
+
+=back
+
+A detailed explanation of each of these parameters and environment
+variable is found below.
+
 =head3 C<< server >>
 
 The C<< server >> parameter specifies the Redis server we should connect to,
@@ -1086,26 +1113,26 @@ via TCP. Use the 'IP:PORT' format. If no C<< server >> option is present, we
 will attempt to use the C<< REDIS_SERVER >> environment variable. If neither of
 those options are present, it defaults to '127.0.0.1:6379'.
 
-Alternatively you can use the C<< sock >> parameter to specify the path of the
-UNIX domain socket where the Redis server is listening.
+=head3 C<< sock >>
 
-Alternatively you can use the C<< sentinels >> parameter and the C<< service >>
-parameter to specify a list of sentinels to contact and try to get the address
-of the given service name. C<< sentinels >> must be an ArrayRef and C<< service
->> an Str.
+The C<< sock >> parameter specifies the path of the UNIX domain socket
+where the Redis server is listening.
 
-The C<< REDIS_SERVER >> can be used for UNIX domain sockets too. The following
-formats are supported:
+=head3 C<< sentinels >> and C<< service >>
+
+The C<< sentinels >> and the C<< service >> parameters specify a list of sentinels to contact and try to get the
+address of the servers supporting the given service name.
+
+The C<< sentinels >> parameter must be an ArrayRef
+and C<< service >> an Str.
+
+=head3 C<< REDIS_SERVER ENV >>
+
+The C<< REDIS_SERVER >> environment variable can be used to specify the
+address or UNIX domain socket to use. The following formats are
+supported:
 
 =over
-
-=item *
-
-/path/to/sock
-
-=item *
-
-unix:/path/to/sock
 
 =item *
 
@@ -1114,6 +1141,14 @@ unix:/path/to/sock
 =item *
 
 tcp:127.0.0.1:11011
+
+=item *
+
+/path/to/sock
+
+=item *
+
+unix:/path/to/sock
 
 =back
 

--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -924,10 +924,14 @@ __END__
     my $redis = Redis->new(write_timeout => 1.2);
 
     ## Connect via a list of Sentinels to a given service
-    my $redis = Redis->new(sentinels => [ '127.0.0.1:12345' ], service => 'mymaster');
+    my $redis = Redis->new(sentinels => [ '127.0.0.1:12345' ], service => 'my_cluster');
+
+    ## Connect to a random slave of a Sentinel monitored service
+    ## it will reconnect to a random different slave on disconnect
+    my $redis = Redis->new(sentinels => [ '127.0.0.1:12345' ], service => 'my_cluster', role => 'slave');
 
     ## Same, but with connection, read and write timeout on the sentinel hosts
-    my $redis = Redis->new( sentinels => [ '127.0.0.1:12345' ], service => 'mymaster',
+    my $redis = Redis->new( sentinels => [ '127.0.0.1:12345' ], service => 'my_cluster',
                             sentinels_cnx_timeout => 0.1,
                             sentinels_read_timeout => 1,
                             sentinels_write_timeout => 1,
@@ -1125,6 +1129,11 @@ address of the servers supporting the given service name.
 
 The C<< sentinels >> parameter must be an ArrayRef
 and C<< service >> an Str.
+
+By default this will connect you to the
+master instance of the service, but you can use the C<< role >> set as
+"slave" to randomly connect to one of the slaves. If no slaves are
+found, the connect call will die. Please note that this means that you can also die on reconnects.
 
 =head3 C<< REDIS_SERVER ENV >>
 

--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -69,6 +69,7 @@ sub new {
   $self->{reconnect}     = $args{reconnect} || 0;
   $self->{conservative_reconnect} = $args{conservative_reconnect} || 0;
   $self->{every}         = $args{every} || 1000;
+  $self->{role}          = $args{role}
 
   if (exists $args{sock}) {
     $self->{server} = $args{sock};
@@ -83,7 +84,7 @@ sub new {
     };
   } elsif ($args{sentinels}) {
       $self->{sentinels} = $args{sentinels};
-      $self->{role} = $args{role} || 'master';
+      $self->{role} ||= 'master';
 
       ref $self->{sentinels} eq 'ARRAY'
         or croak("'sentinels' param must be an ArrayRef");
@@ -1168,6 +1169,15 @@ but you can use the C<< role >> set as "slave" to randomly connect to
 one of the slaves. If no slaves are found, the connect call will die.
 
 Please note that this means that you can also die on reconnects.
+
+=over
+
+=item
+
+Tip: you can actually use C<< role >> to make sure you are connected to
+the correct type of server, even if you don't use Sentinel.
+
+=back
 
 =head3 C<< REDIS_SERVER ENV >>
 

--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -61,7 +61,7 @@ sub new {
   }
 
   defined $args{$_}
-    and $self->{$_} = $args{$_} for 
+    and $self->{$_} = $args{$_} for
       qw(password on_connect name no_auto_connect_on_new cnx_timeout
          write_timeout read_timeout sentinels_cnx_timeout sentinels_write_timeout
          sentinels_read_timeout no_sentinels_list_update);
@@ -139,12 +139,12 @@ sub new {
                       ( sort { $h{$a} <=> $h{$b} } keys %h ), # sorted existing sentinels,
                       grep { ! $h{$_}; }                      # list of unknown
                       map { +{ @$_ }->{name}; }               # names of
-                      $sentinel->sentinel(                    # sentinels 
+                      $sentinel->sentinel(                    # sentinels
                         sentinels => $self->{service}         # for this service
                       )
                   ];
               }
-              
+
               return $self->_maybe_enable_timeouts(
                   IO::Socket::INET->new(
                       PeerAddr => $server_address,
@@ -442,7 +442,7 @@ sub wait_for_messages {
       $s->remove($s->handles);
       $s->add($sock);
 
-      while ($s->can_read($timeout)) {      
+      while ($s->can_read($timeout)) {
         my $has_stuff = $self->__try_read_sock($sock);
         # If the socket is ready to read but there is nothing to read, ( so
         # it's an EOF ), try to reconnect.
@@ -459,7 +459,7 @@ sub wait_for_messages {
           # or undef ( socket became EOF), back to select until timeout
         } while ($self->{__buf} || $self->__try_read_sock($sock));
       }
-    
+
     });
 
   } catch {
@@ -634,14 +634,15 @@ sub __build_sock {
 
 sub __close_sock {
   my ($self) = @_;
+
   $self->{__buf} = '';
   delete $self->{__inside_watch};
   delete $self->{__inside_transaction};
+
   return close(delete $self->{sock});
 }
 
 sub __on_connection {
-
     my ($self) = @_;
 
     if ($self->{role}) {
@@ -662,7 +663,7 @@ sub __on_connection {
             $n = $n->($self) if ref($n) eq 'CODE';
             $self->client_setname($n) if defined $n;
         };
-  
+
       defined $self->{current_database}
         and $self->select($self->{current_database});
     }

--- a/lib/Redis/Sentinel.pm
+++ b/lib/Redis/Sentinel.pm
@@ -35,7 +35,7 @@ sub get_slaves {
     my @slaves;
 
     eval {@slaves = map { +{@$_}; } @{ shift->sentinel('slaves', shift) || [] }; 1 } or do {
-      die unless $@ =~ m/ERR No such master with that name/;
+      die $@ unless $@ =~ m/ERR No such master with that name/;
       return;
     };
 

--- a/lib/Redis/Sentinel.pm
+++ b/lib/Redis/Sentinel.pm
@@ -31,6 +31,17 @@ sub get_masters {
     map { +{ @$_ }; } @{ shift->sentinel('masters') || [] };
 }
 
+sub get_slaves {
+    my @slaves;
+
+    eval {@slaves = map { +{@$_}; } @{ shift->sentinel('slaves', shift) || [] }; 1 } or do {
+      die unless $@ =~ m/ERR No such master with that name/;
+      return;
+    };
+
+    return \@slaves;
+}
+
 1;
 
 __END__
@@ -68,5 +79,13 @@ service were found.
 
 Returns a list of HashRefs representing all the master redis instances that
 this sentinel monitors.
+
+=head2 get_slaves
+
+Takes the name of a service as parameter.
+
+If the service is not known to the sentinels server, returns undef. If
+the service is known, retuns an arrayRef of hashRef's, one for each
+slave available on the service.
 
 =cut


### PR DESCRIPTION
This is still work in progress. It works, but there is stuff missing.

In particular:

* tests: not sure how to test this stuff yet;
* corner case of wrong role detected: we connected during a demotion or promotion of the server we connected to, and the role no longer matches what we expected - we need a clean way to go through the reconnection process.

The first item should be easy, I just need some time with the sentinel tests to understand them well.

The second, I think the best bet is make the code path for Sentinel-based connections to be the same as the "reconnect on" path. We get reconnects for free if we have the wrong server Role, and the build sock stuff already takes care of going through Sentinel to pick up a new server.

Anyway, please review…

Test script during development:

```perl
#!/usr/bin/env perl

use 5.014;
use warnings;
use lib 'lib';
use Redis::Sentinel;
use Data::Dumper;

my $r = Redis->new(
  sentinels => ['127.0.0.1:2001', '127.0.0.1:2002', '127.0.0.1:2003'],
  service   => 't',
  role      => 'slave',
);

my $i = $r->info('replication');
warn "from $r->{server}: " . Dumper($i);
```