### PR TITLE
Provide additional information on Redis authentication error

### DIFF
--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -611,8 +611,9 @@ sub __build_sock {
   if (exists $self->{password}) {
     try { $self->auth($self->{password}) }
     catch {
+      my $error = $_;
       $self->{reconnect} = 0;
-      croak("Redis server refused password");
+      croak('Redis server authentication error: ' . $error);
     };
   }
 


### PR DESCRIPTION
As currently implemented, it's not possible to see the exact error happened during Redis authentication. In our case we had libc error "Resource temporarily unavailable", which we could not see before the change.