### PR TITLE
remove develop prereqs from test prereqs again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ perl:
 before_install:
   - "git config --global user.name TravisCI"
   - "git config --global github.user dams"
-install: "dzil authordeps | xargs cpanm --quiet --notest && dzil listdeps | xargs cpanm --quiet --notest"
+install: "dzil authordeps | xargs cpanm --quiet --notest && dzil listdeps --develop | xargs cpanm --quiet --notest"
 script: "dzil test --release"

--- a/dist.ini
+++ b/dist.ini
@@ -61,8 +61,6 @@ Test::Deep = 0
 Test::Fatal = 0
 Test::More = 0.98
 Test::TCP = 1.19
-Test::CPAN::Meta = 0
-Pod::Coverage::TrustPod = 0
 
 ; -- release
 [NextRelease]


### PR DESCRIPTION
This re-fixes issue #92 that was fixed in 6a3e7cb8 and then reverted in 0fd70703.
It is not necessary to list these prereqs at all, as the plugins that
use them will add them.