### PR TITLE
relax the check in 04-pipeline.t about unknown command output

### DIFF
--- a/t/04-pipeline.t
+++ b/t/04-pipeline.t
@@ -36,7 +36,7 @@ sub pipeline_ok {
 pipeline_ok 'single-command pipeline', ([set => [foo => 'bar'], 'OK'],);
 
 pipeline_ok 'pipeline with embedded error',
-  ([set => [clunk => 'eth'], 'OK'], [oops => [], undef, q[ERR unknown command 'OOPS']], [get => ['clunk'], 'eth'],);
+  ([set => [clunk => 'eth'], 'OK'], [oops => [], undef, re(qr{^ERR unknown command .OOPS.})], [get => ['clunk'], 'eth'],);
 
 pipeline_ok 'keys in pipelined mode',
   ([keys => ['*'], bag(qw<foo clunk>)], [keys => [], undef, q[ERR wrong number of arguments for 'keys' command]],);


### PR DESCRIPTION

In Debian we are currently applying the following patch to Redis.
We thought you might be interested in it too.

    Description: relax the check in 04-pipeline.t about unknown command output
     It appears that redis-server 4.0.11 changed its error message when given
     unknown commands. It is now something like
     .
        ERR unknown command `OOPS`, with args beginning with: '
     .
     Redis 3 was giving:
     .
        ERR unknown command 'OOPS'
     .
     This change adapts the test so that it passes with redis-server 3 and 4.
    Author: Damyan Ivanov <dmn@debian.org>

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libredis-perl/raw/master/debian/patches/unknown-command-err-changed.patch

Thanks for considering,
  Damyan Ivanov,
  Debian Perl Group
