### PR TITLE
Patch to support RedisTimeSeries commands.

### DIFF
--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -194,7 +194,7 @@ our $AUTOLOAD;
 sub AUTOLOAD {
   my $command = $AUTOLOAD;
   $command =~ s/.*://;
-
+  if ($command =~ /^ts/) { substr($command,2,0) = ".";}
   my $method = sub { shift->__std_cmd($command, @_) };
 
   # Save this method for future calls


### PR DESCRIPTION
RedisTimeSeries https://oss.redislabs.com/redistimeseries/
. character was unsupported but now it works for commands beginning with 'ts'.
Assumption made that no other commands begin with 'ts'.
usage: $redis->tscreate(....), tsadd(....) etc.

First pull request made so excuse me if I've missed something.
No tests written as I'm not sure how to do that.

Not sure the change is good enough but please review.