### PR TITLE
Fix for "Unexpected error condition 104/linux"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ before_install:
   - "git config --global github.user dams"
 install:
  - "dzil authordeps | xargs cpanm --quiet --notest && dzil listdeps --develop | xargs cpanm --quiet --notest"
+ - "dzil authordeps --missing | cpanm"
 script: "dzil test --release"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,12 @@ perl:
   - "5.14"
   - "5.12"
   - "5.10"
+sudo: required
 before_install:
+  - "sudo apt-get update -q"
+  - "sudo apt-get install libdist-zilla-perl"
   - "git config --global user.name TravisCI"
   - "git config --global github.user dams"
 install:
- - "cpanm  --quiet  --notest --skip-installed Dist::Zilla"
  - "dzil authordeps | xargs cpanm --quiet --notest && dzil listdeps --develop | xargs cpanm --quiet --notest"
 script: "dzil test --release"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,7 @@ perl:
 before_install:
   - "git config --global user.name TravisCI"
   - "git config --global github.user dams"
-install: "dzil authordeps | xargs cpanm --quiet --notest && dzil listdeps --develop | xargs cpanm --quiet --notest"
+install:
+ - "cpanm  --quiet  --notest --skip-installed Dist::Zilla"
+ - "dzil authordeps | xargs cpanm --quiet --notest && dzil listdeps --develop | xargs cpanm --quiet --notest"
 script: "dzil test --release"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,14 @@ language: perl
 services:
   - redis-server
 perl:
-  - "5.16"
-  - "5.14"
-  - "5.12"
-  - "5.10"
-sudo: required
+  - "5.22"
+  - "5.26"
+  - "5.28"
+  - "5.30"
 before_install:
-  - "sudo apt-get update -q"
-  - "sudo apt-get install libdist-zilla-perl"
   - "git config --global user.name TravisCI"
   - "git config --global github.user dams"
 install:
+ - "cpanm --quiet --notest Dist::Zilla"
  - "dzil authordeps | xargs cpanm --quiet --notest && dzil listdeps --develop | xargs cpanm --quiet --notest"
- - "dzil authordeps --missing | cpanm"
 script: "dzil test --release"

--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -875,7 +875,7 @@ sub __try_read_sock {
       ## Keep going if nothing there, but socket is alive
       return 0 if $err and ($err == EWOULDBLOCK or $err == EAGAIN);
 
-      ## if we got ECONNRESET, it's might be due a timeout from the other side (on freebsd)
+      ## if we got ECONNRESET, it might be due a timeout from the other side (on freebsd)
       ## or because an intermediate proxy shut down our connection using its internal timeout counter
       return 0 if ($err && $err == ECONNRESET);
 

--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -875,8 +875,9 @@ sub __try_read_sock {
       ## Keep going if nothing there, but socket is alive
       return 0 if $err and ($err == EWOULDBLOCK or $err == EAGAIN);
 
-      ## on freebsd, if we got ECONNRESET, it's a timeout from the other side
-      return 0 if ($err && $err == ECONNRESET && $^O eq 'freebsd');
+      ## if we got ECONNRESET, it's might be due a timeout from the other side (on freebsd)
+      ## or because an intermediate proxy shut down our connection using its internal timeout counter
+      return 0 if ($err && $err == ECONNRESET);
 
       ## result is undef but err is 0? should never happen
       return if $err == 0;


### PR DESCRIPTION
If Redis connection is routed thorugh an intermediate proxy (e.g. HAProxy)
it might be forcefully reset due to internal proxy timeout settings.

This patch attempts to fix that by making sure that we treat ECONNRESET
error code on all platforms, not just freebsd. Effectively this change
would make Redis library to reconnect in the event of RST packet
received.