### PR TITLE
Make try/catch syntax same as rest of code

### DIFF
--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -248,22 +248,22 @@ sub __with_reconnect {
   $self->{reconnect}
     or return $cb->();
 
-  return &try(
-    $cb,
-    catch {
-      ref($_) eq 'Redis::X::Reconnect'
-        or die $_;
+  return try {
+    $cb->();
+  }
+  catch {
+    ref($_) eq 'Redis::X::Reconnect'
+      or die $_;
 
-      $self->{__inside_transaction} || $self->{__inside_watch}
-        and croak("reconnect disabled inside transaction or watch");
+    $self->{__inside_transaction} || $self->{__inside_watch}
+      and croak("reconnect disabled inside transaction or watch");
 
-      scalar @{$self->{queue} || []} && $self->{conservative_reconnect}
-        and croak("reconnect disabled while responses are pending and conservative reconnect mode enabled");
+    scalar @{$self->{queue} || []} && $self->{conservative_reconnect}
+      and croak("reconnect disabled while responses are pending and conservative reconnect mode enabled");
 
-      $self->connect;
-      $cb->();
-    }
-  );
+    $self->connect;
+    $cb->();
+  }
 }
 
 sub __run_cmd {


### PR DESCRIPTION
The previous syntax `&try( $cb, catch { ... } );` was non-standard and unnecessarily confusing.

This change makes the try/catch syntax look more normal and brings it in line with the rest of the code in the module.

By ignoring whitespace differences, the code change can be seen more clearly:
```
$ gitdiff -b
diff --git lib/Redis.pm lib/Redis.pm
index bad04f5..196d8f4 100644
--- lib/Redis.pm
+++ lib/Redis.pm
@@ -248,8 +248,9 @@ sub __with_reconnect {
   $self->{reconnect}
     or return $cb->();
 
-  return &try(
-    $cb,
+  return try {
+    $cb->();
+  }
   catch {
     ref($_) eq 'Redis::X::Reconnect'
       or die $_;
@@ -263,7 +264,6 @@ sub __with_reconnect {
     $self->connect;
     $cb->();
   }
-  );
 }
 
 sub __run_cmd {
```