### PR TITLE
fix typo of the sentinels option

### DIFF
--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -49,7 +49,7 @@ sub new {
   $self->{debug} = $args{debug} || $ENV{REDIS_DEBUG};
 
   ## Deal with REDIS_SERVER ENV
-  if ($ENV{REDIS_SERVER} && ! exists $args{sock} && ! exists $args{server} && ! exists $args{sentinel}) {
+  if ($ENV{REDIS_SERVER} && ! exists $args{sock} && ! exists $args{server} && ! exists $args{sentinels}) {
     if ($ENV{REDIS_SERVER} =~ m!^/!) {
       $args{sock} = $ENV{REDIS_SERVER};
     }


### PR DESCRIPTION
It seems that `sentinel` is a typo of `sentinels`, because `$args{sentinel}` is only used here.
