### PR TITLE
Add scan_callback, hscan_callback, and sscan_callback method to iterate over keys comfortably

### DIFF
--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -2087,6 +2087,20 @@ Remove one or more members from a set (see L<https://redis.io/commands/srem>)
 
 Incrementally iterate Set elements (see L<https://redis.io/commands/sscan>)
 
+=head2 sscan_callback
+
+  $r->sscan_callback( $hashkey, sub { print "$_[0]\n" } );
+
+  $r->sscan_callback( $hashkey, "prefix:*", sub {
+    my ($key, $value) = @_;
+    ...
+  });
+
+Execute callback exactly once for every key matching a pattern
+(of "*" if none given). L</sscan> is used internally.
+
+A (key, value) pair will be passed to the callback as arguments.
+
 =head2 sunion
 
   $r->sunion(key [key ...])

--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -469,17 +469,22 @@ sub scan_callback {
   my $self = shift;
   my $cb = pop;
   my $pattern = shift || '*';
+  # TODO how do we pass TYPE and COUNT arguments?
 
+  croak("Missing required callback in call to scan_callback(), ")
+    unless ref($cb) eq 'CODE';
+
+  # TODO how do we implement HSCAN/ZSCAN? Can't use $_ there
+  #      because they iterate over _pairs_, not just keys.
   my $cursor = 0;
   do {
     ($cursor, my $list) = $self->scan( $cursor, MATCH => $pattern );
-    local $_;
     for (@$list) {
       $cb->($self, $_);
     };
   } while $cursor;
 
-  return $self; 
+  return 1; 
 }
 
 ### PubSub

--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -465,6 +465,22 @@ sub keys {
   );
 }
 
+sub scan_callback {
+  my $self = shift;
+  my $cb = pop;
+  my $pattern = shift || '*';
+
+  my $cursor = 0;
+  do {
+    ($cursor, my $list) = $self->scan( $cursor, MATCH => $pattern );
+    local $_;
+    for (@$list) {
+      $cb->($self, $_);
+    };
+  } while $cursor;
+
+  return $self; 
+}
 
 ### PubSub
 sub wait_for_messages {
@@ -1676,6 +1692,22 @@ Incrementally iterate the keys space (see L<https://redis.io/commands/scan>)
   my $cursor = 0;  my $result = [];
   do { ($cursor, $result) = $r->scan($cursor, 'MATCH', '*'); ... }
       while ( $cursor );
+
+=head2 scan_callback
+
+  $r->scan_callback( sub { print "$_\n" } );
+
+  $r->scan_callback( "prefix:*", sub {
+    my ($connection, $key) = @_;
+    ...
+  });
+
+Execute callback exactly once for every key matching a pattern
+(of "*" if none given). L</scan> is used internally.
+
+C<$_> is localized and set to the key so shorter callbacks can be used.
+
+Callback arguments are ($r, $key).
 
 =head2 sort
 

--- a/lib/Redis.pm
+++ b/lib/Redis.pm
@@ -471,7 +471,7 @@ sub scan_callback {
   my $pattern = shift || '*';
   # TODO how do we pass TYPE and COUNT arguments?
 
-  croak("Missing required callback in call to scan_callback(), ")
+  croak("[scan_callback] The last argument must be a function")
     unless ref($cb) eq 'CODE';
 
   # TODO how do we implement HSCAN/ZSCAN? Can't use $_ there
@@ -479,12 +479,12 @@ sub scan_callback {
   my $cursor = 0;
   do {
     ($cursor, my $list) = $self->scan( $cursor, MATCH => $pattern );
-    for (@$list) {
-      $cb->($self, $_);
+    foreach my $key (@$list) {
+      $cb->($key);
     };
   } while $cursor;
 
-  return 1; 
+  return 1;
 }
 
 ### PubSub
@@ -1700,19 +1700,17 @@ Incrementally iterate the keys space (see L<https://redis.io/commands/scan>)
 
 =head2 scan_callback
 
-  $r->scan_callback( sub { print "$_\n" } );
+  $r->scan_callback( sub { print "$_[0]\n" } );
 
   $r->scan_callback( "prefix:*", sub {
-    my ($connection, $key) = @_;
+    my ($key) = @_;
     ...
   });
 
 Execute callback exactly once for every key matching a pattern
 (of "*" if none given). L</scan> is used internally.
 
-C<$_> is localized and set to the key so shorter callbacks can be used.
-
-Callback arguments are ($r, $key).
+The key in question will be the only argument of the callback.
 
 =head2 sort
 

--- a/t/12-scan-callback.t
+++ b/t/12-scan-callback.t
@@ -50,5 +50,30 @@ subtest 'scan with pattern' => sub {
   is_deeply( [sort @trace], [sort qw[bar baz]], 'only selected keys scanned once' );
 };
 
+$o->hset( "hash", "foo", 42 );
+$o->hset( "hash", "bar", 137 );
+
+subtest 'shotgun sscan' => sub {
+  my %copy;
+
+  $o->hscan_callback( "hash", sub {
+    my ($key, $value) = @_;
+    $copy{$key} += $value;
+  });
+
+  is_deeply \%copy, { foo => 42, bar => 137 }, 'each key processed exactly once';
+};
+
+subtest 'sscan with pattern' => sub {
+  my %copy;
+
+  $o->hscan_callback( "hash", "ba*", sub {
+    my ($key, $value) = @_;
+    $copy{$key} += $value;
+  });
+
+  is_deeply \%copy, { bar => 137 }, 'only matching keys processed exactly once';
+};
+
 
 done_testing;

--- a/t/12-scan-callback.t
+++ b/t/12-scan-callback.t
@@ -1,0 +1,54 @@
+#!perl
+
+use warnings;
+use strict;
+use Test::More;
+use Test::Fatal;
+use Redis;
+use lib 't/tlib';
+use Test::SpawnRedisServer;
+
+use constant SSL_AVAILABLE => eval { require IO::Socket::SSL } || 0;
+
+my ($c, $t, $srv) = redis();
+END {
+  $c->() if $c;
+  $t->() if $t;
+}
+
+my $use_ssl = $t ? SSL_AVAILABLE : 0;
+
+my $o;
+is(
+  exception { $o = Redis->new(server => $srv,
+                              name => 'my_name_is_glorious',
+                              ssl => $use_ssl,
+                              SSL_verify_mode => 0) },
+  undef, 'connected to our test redis-server',
+);
+
+my %vals = (
+  foo => 1,
+  bar => 2,
+  baz => 3,
+  quux => 4,
+);
+
+$o->set($_, $vals{$_}) for keys %vals;
+
+subtest 'shotgun scan' => sub {
+  my @trace;
+  $o->scan_callback(sub { push @trace, $_ });
+
+  is_deeply( [sort @trace], [sort keys %vals], 'all keys scanned once' );
+};
+
+subtest 'scan with pattern' => sub {
+  my @trace;
+  $o->scan_callback('ba*', sub { push @trace, $_ });
+
+  is_deeply( [sort @trace], [sort qw[bar baz]], 'only selected keys scanned once' );
+};
+
+
+done_testing;

--- a/t/12-scan-callback.t
+++ b/t/12-scan-callback.t
@@ -38,14 +38,14 @@ $o->set($_, $vals{$_}) for keys %vals;
 
 subtest 'shotgun scan' => sub {
   my @trace;
-  $o->scan_callback(sub { push @trace, $_ });
+  $o->scan_callback(sub { push @trace, $_[0] });
 
   is_deeply( [sort @trace], [sort keys %vals], 'all keys scanned once' );
 };
 
 subtest 'scan with pattern' => sub {
   my @trace;
-  $o->scan_callback('ba*', sub { push @trace, $_ });
+  $o->scan_callback('ba*', sub { push @trace, $_[0] });
 
   is_deeply( [sort @trace], [sort qw[bar baz]], 'only selected keys scanned once' );
 };


### PR DESCRIPTION
Redis's `*SCAN` methods are quite cumbersome to use in Perl. This wrapper abstracts away the cursor handling and calls a user-specified callback exactly once per key.

The callback is always expected as the LAST argument as that makes reading the resulting code easier.