### PR TITLE
Added zscan_callback + added hash parameters instead of single MATCH pattern.

### DIFF
--- a/t/12-scan-callback.t
+++ b/t/12-scan-callback.t
@@ -67,7 +67,7 @@ subtest 'shotgun hscan' => sub {
 subtest 'hscan with pattern' => sub {
   my %copy;
 
-  $o->hscan_callback( "hash", "ba*", sub {
+  $o->hscan_callback( "hash", MATCH => "ba*", sub {
     my ($key, $value) = @_;
     $copy{$key} += $value;
   });
@@ -93,12 +93,23 @@ subtest 'sscan (iteration over set)' => sub {
 
   {
     my %copy;
-    $o->sscan_callback( "zfc", "x:*", sub {
+    $o->sscan_callback( "zfc", MATCH => "x:*", sub {
       my $entry = shift;
       $copy{$entry}++;
     });
     is_deeply \%copy, \%restricted, 'only matching values in set listed exactly once';
   };
+};
+
+subtest 'zscan' => sub {
+  $o->zadd( "sorted", 1, "first", 2, "second", 3, "x", 3, "y", 3, "z" );
+  my @trace;
+  $o->zscan_callback( "sorted", sub { push @trace, \@_ } );
+  is_deeply(
+    \@trace,
+    [[ first => 1 ], [ second => 2 ], [ x => 3 ], [ y => 3 ], [ z => 3 ]],
+    "sorted set iterated in order"
+  );
 };
 
 # TODO add a scan(TYPE => 'set') call


### PR DESCRIPTION
Followup to #170. 

* zscan_callback added
* all *scan_callback methods now accept a hash of parameters instead of a single pattern.